### PR TITLE
Update ClojureScript dep to 2138

### DIFF
--- a/src/leiningen/new/mies/project.clj
+++ b/src/leiningen/new/mies/project.clj
@@ -3,7 +3,7 @@
   :url "http://example.com/FIXME"
 
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/clojurescript "0.0-2127"]]
+                 [org.clojure/clojurescript "0.0-2138"]]
 
   :plugins [[lein-cljsbuild "1.0.1"]]
 


### PR DESCRIPTION
This allows the mies template to be used with Om, which now requires at least 2134 due to ICloneable.
