### PR TITLE
Add some HTML to avoid web console errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,24 @@ lein new mies hello-world
 cd hello-world
 ```
 
-To compile clojurescript and get a working web-page:
+To compile a developer build version:
 ```
-lein cljsbuild auto
+scripts/build
+```
+
+To continuously monitor source files and build when changed:
+```
+scripts/watch
+```
+
+To compile a release version:
+```
+scripts/release
 ```
 
 ## License
 
-Copyright © 2013 David Nolen
+Copyright © 2013-2015 David Nolen
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.

--- a/src/leiningen/new/mies/index.html
+++ b/src/leiningen/new/mies/index.html
@@ -1,4 +1,9 @@
+<!DOCTYPE html>
 <html>
+    <head>
+        <title>{{name}}</title>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    </head>
     <body>
         <script src="out/goog/base.js" type="text/javascript"></script>
         <script src="out/{{sanitized}}.js" type="text/javascript"></script>

--- a/src/leiningen/new/mies/index_release.html
+++ b/src/leiningen/new/mies/index_release.html
@@ -1,4 +1,9 @@
+<!DOCTYPE html>
 <html>
+    <head>
+        <title>{{name}}</title>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    </head>
     <body>
         <script src="out/{{sanitized}}.min.js" type="text/javascript"></script>
     </body>

--- a/src/leiningen/new/mies/index_release.html
+++ b/src/leiningen/new/mies/index_release.html
@@ -5,6 +5,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     </head>
     <body>
-        <script src="out-adv/{{sanitized}}.min.js" type="text/javascript"></script>
+        <script src="release/{{sanitized}}.min.js" type="text/javascript"></script>
     </body>
 </html>

--- a/src/leiningen/new/mies/release.clj
+++ b/src/leiningen/new/mies/release.clj
@@ -4,7 +4,7 @@
 
 (let [start (System/nanoTime)]
   (cljsc/build "src"
-    {:output-to "out/{{sanitized}}.js"
+    {:output-to "release/{{sanitized}}.js"
      :output-dir "release"
      :optimizations :advanced
      :verbose true})


### PR DESCRIPTION
When loaded into Firefox, the existing index.html file produces this error in the web console:
````
The character encoding of the HTML document was not declared. The document will 
ender with garbled text in some browser configurations if the document contains
characters from outside the US-ASCII range. The character encoding of the page must be
declared in the document or in the transfer protocol.
````
I've added a `<head>` and `<meta>` element to eliminate the error, and I also added a `<title>` element to further identify the project when loaded into the browser. (I know that "less is more"&mdash;I am guessing that's why the template is called `mies`&mdash;so I hope I haven't added *too* much more.)