### PR TITLE
add .repl* to gitignore

### DIFF
--- a/src/leiningen/new/mies/gitignore
+++ b/src/leiningen/new/mies/gitignore
@@ -8,3 +8,4 @@ pom.xml
 .lein-deps-sum
 .lein-repl-history
 .lein-plugins/
+.repl*


### PR DESCRIPTION
otherwise, after following the readme instructions for enabling the repl there are a bunch of files waiting to be (wrongly) added.