### PR TITLE
Fix ClassNotFoundException with Java 9

### DIFF
--- a/src/leiningen/new/mies/project.clj
+++ b/src/leiningen/new/mies/project.clj
@@ -3,7 +3,7 @@
   :url "http://example.com/FIXME"
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/clojurescript "1.9.671"]]
-  :jvm-opts ^:replace ["-Xmx1g" "-server"]
+  :jvm-opts ^:replace ["-Xmx1g" "-server" "--add-modules" "java.xml.bind"]
   :plugins [[lein-npm "0.6.2"]]
   :npm {:dependencies [[source-map-support "0.4.0"]]}
   :source-paths ["src" "target/classes"]


### PR DESCRIPTION
I am getting a ClassNotFoundException with Java 9 installed on my machine. I've found people solving the same issue in Figwheel: https://github.com/bhauman/lein-figwheel/issues/612. After adding this parameter the exception is gone.